### PR TITLE
Remove deprecated and unnecessary dependency on telnetlib

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 from powermate import PowerMateBase, LedEvent, MAX_BRIGHTNESS
 import glob
-import telnetlib
 import subprocess
 import os
 try:


### PR DESCRIPTION
Telnetlib has been deprecated since Python 3.11 and was removed in 3.13 breaking the knob. Luckily it wasn't in use and everything functions fine without it. 